### PR TITLE
BUG: Link to symbols required for the plugin to load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,8 @@ PluginProperties(TARGET_NAME ${plug_target_name}
 target_link_libraries(${plug_target_name}
                     Qt5::Core
                     SIMPLib
+                    ${ITK_LIBRARIES}
+                    ITKImageProcessingServer
 )
 
 # -------------------------------------------------------------------- 


### PR DESCRIPTION
@imikejackson should these libraries be linked to the `MultiscaleFusionServer` target, too?